### PR TITLE
if tweet length is more than 280 characters, push the tweet as a thread, rather than truncating or throwing an error

### DIFF
--- a/src/connections/twitter_connection.py
+++ b/src/connections/twitter_connection.py
@@ -439,9 +439,43 @@ class TwitterConnection(BaseConnection):
 
     def post_tweet(self, message: str, **kwargs) -> dict:
         """Post a new tweet"""
-        logger.debug("Posting new tweet")
-        self._validate_tweet_text(message)
+        # If message is longer than 280 chars, split into thread
+        if len(message) > 280:
+            logger.info("Message exceeds 280 characters, creating thread")
+            tweets = self._split_into_thread(message)
+            
+            # Post first tweet
+            response = self._make_request('post', 'tweets', json={'text': tweets[0]})
+            previous_tweet_id = response['data']['id']
+            
+            # Post rest of thread
+            for tweet in tweets[1:]:
+                response = self._make_request('post', 'tweets',
+                    json={
+                        'text': tweet,
+                        'reply': {
+                            'in_reply_to_tweet_id': previous_tweet_id
+                        }
+                    })
+                previous_tweet_id = response['data']['id']
+        else:
+            response = self._make_request('post', 'tweets', json={'text': message})
+        return response
 
+    def _split_into_thread(self, message: str) -> list:
+        """Split long message into thread-sized chunks"""
+        tweets = []
+        while message:
+            if len(message) <= 280:
+                tweets.append(message)
+                break
+            # Find last space before 280 chars
+            split_point = message[:280].rfind(' ')
+            if split_point == -1:
+                split_point = 280
+            tweets.append(message[:split_point])
+            message = message[split_point:].strip()
+        return tweets"
         response = self._make_request('post', 'tweets', json={'text': message})
 
         logger.info("Tweet posted successfully")


### PR DESCRIPTION
if tweet length is more than 280 characters, push the tweet as a thread, rather than truncating or throwing an error